### PR TITLE
사용자 프로필 조회기능 개발

### DIFF
--- a/src/main/java/com/mycom/myapp/config/SecurityConfig.java
+++ b/src/main/java/com/mycom/myapp/config/SecurityConfig.java
@@ -19,7 +19,8 @@ public class SecurityConfig {
 								"/api/user/register",
 								"/api/user/email-check",
 								"/api/auth/login",
-								"api/auth/logout"
+								"api/auth/logout",
+								"/api/user/profile"
 						).permitAll()
 				)
 				.csrf(csrf -> csrf.disable())

--- a/src/main/java/com/mycom/myapp/user/controller/UserController.java
+++ b/src/main/java/com/mycom/myapp/user/controller/UserController.java
@@ -53,11 +53,14 @@ public class UserController {
 	}
 
 	@GetMapping("/profile")
-	public ResponseEntity<UserProfileResponseDto> getUserProfile(HttpSession session) {
-		LoginResponseDto loginUser = (LoginResponseDto) session.getAttribute("loginUser");
-		if (loginUser == null) {
+	public ResponseEntity<UserProfileResponseDto> getUserProfile(Authentication authentication) {
+		if(authentication == null || !authentication.isAuthenticated() ||
+				authentication.getPrincipal() instanceof String) {
 			return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
 		}
+
+		LoginResponseDto loginUser = (LoginResponseDto) authentication.getPrincipal();
+
 		try {
 			UserProfileResponseDto profile = userService.getUserProfileById(loginUser.getId());
 			return ResponseEntity.ok(profile);

--- a/src/main/java/com/mycom/myapp/user/controller/UserController.java
+++ b/src/main/java/com/mycom/myapp/user/controller/UserController.java
@@ -1,6 +1,10 @@
 package com.mycom.myapp.user.controller;
 
+import com.mycom.myapp.auth.dto.response.LoginResponseDto;
+import com.mycom.myapp.user.dto.UserProfileResponseDto;
 import com.mycom.myapp.user.dto.UserRegisterRequestDto;
+import jakarta.servlet.http.HttpSession;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -33,4 +37,19 @@ public class UserController {
 	    boolean isDuplicate = userService.isEmailDuplicate(email);
 	    return ResponseEntity.ok(!isDuplicate);
 	}
+
+	@GetMapping("/profile")
+	public ResponseEntity<UserProfileResponseDto> getUserProfile(HttpSession session) {
+		LoginResponseDto loginUser = (LoginResponseDto) session.getAttribute("loginUser");
+		if (loginUser == null) {
+			return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+		}
+		try {
+			UserProfileResponseDto profile = userService.getUserProfileById(loginUser.getId());
+			return ResponseEntity.ok(profile);
+		} catch (IllegalArgumentException e) {
+			return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+		}
+	}
 }
+

--- a/src/main/java/com/mycom/myapp/user/dto/UserProfileResponseDto.java
+++ b/src/main/java/com/mycom/myapp/user/dto/UserProfileResponseDto.java
@@ -1,0 +1,13 @@
+package com.mycom.myapp.user.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class UserProfileResponseDto {
+    private int id;
+    private String name;
+    private String email;
+    private String profileImg;
+}

--- a/src/main/java/com/mycom/myapp/user/service/UserService.java
+++ b/src/main/java/com/mycom/myapp/user/service/UserService.java
@@ -1,8 +1,10 @@
 package com.mycom.myapp.user.service;
 
+import com.mycom.myapp.user.dto.UserProfileResponseDto;
 import com.mycom.myapp.user.dto.UserRegisterRequestDto;
 
 public interface UserService {
 	boolean insertUser(UserRegisterRequestDto userRegisterRequestDto);
 	boolean isEmailDuplicate(String email);
+	UserProfileResponseDto getUserProfileById(int userId);
 }

--- a/src/main/java/com/mycom/myapp/user/service/UserServiceImpl.java
+++ b/src/main/java/com/mycom/myapp/user/service/UserServiceImpl.java
@@ -1,5 +1,6 @@
 package com.mycom.myapp.user.service;
 
+import com.mycom.myapp.user.dto.UserProfileResponseDto;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -40,6 +41,19 @@ public class UserServiceImpl implements UserService{
 	@Override
 	public boolean isEmailDuplicate(String email) {
 		return userRepository.findByEmail(email).isPresent();
+	}
+
+	@Override
+	public UserProfileResponseDto getUserProfileById(int userId) {
+		User user = userRepository.findById(userId)
+				.orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+		return UserProfileResponseDto.builder()
+				.id(user.getId())
+				.name(user.getName())
+				.email(user.getEmail())
+				.profileImg(user.getProfileImg())
+				.build();
 	}
 }
 


### PR DESCRIPTION
**구현 내용**

- 세션 기반 사용자 프로필 조회(이름, 이메일, 프로필 이미지)
- user/dto에 UserProfileResponseDto 추가
- SecurityConfig 파일 .requestMatchers().permitAll()에  /api/user/profile 경로 추가
-> 
profile은 로그인 없이 접근하면 안되기 때문에 추가하지 않으려고 했는데 permit 하지 않으면 403 에러가 뜹니다. 
경로 추가를 하지 않는다면 Spring Security가 세션 인증을 활용하도록 별도로 설정을 추가 해야한다고 합니다.
그래서 지금은 경로를 추가하고 UserController에서 로그인 하지 않으면 즉 session의 loginUser가 null이면 401 Unauthorized를 보내도록 설정해두었습니다.

- UserController: /api/user/profile 구현
-session의 loginUser에서 id를 얻어올 수 있어서 /api/user/{userid} -> /api/user/profile 로 변경 (괜찮다면 추후에 명세에 반영)
-session의 loginUser가 null 즉 로그인을 하지 않으면 UNAUTHORIZED 응답
-db에서 사용자를 찾을 수 없다면 NOT_FOUND 응답

- UserServiceImpl: id로부터 사용자 프로필 찾고 UserProfileResponseDto로 응답

**chore: 충돌 해결, 프로필 조회 Authentication 기반 처리** commits에 반영된 부분

- 충돌 파일 정리(로그인 인증 부분, 비밀번호 변경 기능은 추가)
- UserController: Authentication를 통한 프로필 조회로 수정
