### PR TITLE
비밀번호 변경 기능 및 로그인 인증 정보 세션 저장 처리

### DIFF
--- a/src/main/java/com/mycom/myapp/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/mycom/myapp/auth/service/AuthServiceImpl.java
@@ -6,8 +6,20 @@ import com.mycom.myapp.user.entity.User;
 import com.mycom.myapp.user.repository.UserRepository;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.authentication.WebAuthenticationDetails;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import java.util.Collections;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -20,9 +32,9 @@ public class AuthServiceImpl implements AuthService {
     @Override
     public boolean login(LoginRequestDto loginRequestDto, HttpSession session) {
         User user = userRepository.findByEmail(loginRequestDto.getEmail())
-                .orElseThrow( () -> new IllegalArgumentException("이메일 또는 비밀번호가 일치하지 않습니다.") );
+                .orElseThrow(() -> new IllegalArgumentException("이메일 또는 비밀번호가 일치하지 않습니다."));
 
-        if( !passwordEncoder.matches(loginRequestDto.getPassword(), user.getPassword()) ) {
+        if (!passwordEncoder.matches(loginRequestDto.getPassword(), user.getPassword())) {
             throw new IllegalArgumentException("이메일 또는 비밀번호가 일치하지 않습니다.");
         }
 
@@ -32,7 +44,24 @@ public class AuthServiceImpl implements AuthService {
                 .email(user.getEmail())
                 .profileImg(user.getProfileImg())
                 .build();
+
+        List<GrantedAuthority> authorities = Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"));
+
+        UsernamePasswordAuthenticationToken authentication =
+                new UsernamePasswordAuthenticationToken(userDto, null, authorities);
+
+        authentication.setDetails(new WebAuthenticationDetails(((ServletRequestAttributes) RequestContextHolder.getRequestAttributes()).getRequest()));
+
+        SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
+        securityContext.setAuthentication(authentication);
+        SecurityContextHolder.setContext(securityContext);
+
+        session.setAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY, securityContext);
+
         session.setAttribute("loginUser", userDto);
+
+        System.out.println("Authentication set in SecurityContext: " + SecurityContextHolder.getContext().getAuthentication());
+        System.out.println("Authentication stored in session: " + session.getAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY));
 
         return true;
     }

--- a/src/main/java/com/mycom/myapp/config/SecurityConfig.java
+++ b/src/main/java/com/mycom/myapp/config/SecurityConfig.java
@@ -3,10 +3,14 @@ package com.mycom.myapp.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
+import org.springframework.security.web.context.SecurityContextRepository;
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+import org.springframework.security.web.session.HttpSessionEventPublisher;
 
 @Configuration
 public class SecurityConfig {
@@ -19,8 +23,16 @@ public class SecurityConfig {
 								"/api/user/register",
 								"/api/user/email-check",
 								"/api/auth/login",
-								"api/auth/logout"
+								"/api/auth/logout"
 						).permitAll()
+						.requestMatchers("/api/user/*/password").permitAll()
+						.anyRequest().authenticated()
+				)
+				.sessionManagement(session -> session
+						.sessionCreationPolicy(SessionCreationPolicy.ALWAYS)
+				)
+				.securityContext(context -> context
+						.securityContextRepository(new HttpSessionSecurityContextRepository())
 				)
 				.csrf(csrf -> csrf.disable())
 				.build();
@@ -30,5 +42,15 @@ public class SecurityConfig {
 	PasswordEncoder passwordEncoder() {
 		return new BCryptPasswordEncoder();
 	}
-	
+
+	@Bean
+	public HttpSessionEventPublisher httpSessionEventPublisher() {
+		return new HttpSessionEventPublisher();
+	}
+
+	@Bean
+	public SecurityContextRepository securityContextRepository() {
+		return new HttpSessionSecurityContextRepository();
+	}
+
 }

--- a/src/main/java/com/mycom/myapp/user/controller/UserController.java
+++ b/src/main/java/com/mycom/myapp/user/controller/UserController.java
@@ -1,13 +1,13 @@
 package com.mycom.myapp.user.controller;
 
+import com.mycom.myapp.auth.dto.response.LoginResponseDto;
+import com.mycom.myapp.user.dto.ChangePasswordRequestDto;
 import com.mycom.myapp.user.dto.UserRegisterRequestDto;
+import jakarta.servlet.http.HttpSession;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
 import com.mycom.myapp.user.service.UserService;
 
 import lombok.RequiredArgsConstructor;
@@ -32,5 +32,26 @@ public class UserController {
 	public ResponseEntity<Boolean> checkEmailDuplicate(@RequestParam("email") String email) {
 	    boolean isDuplicate = userService.isEmailDuplicate(email);
 	    return ResponseEntity.ok(!isDuplicate);
+	}
+
+	@PutMapping("{userId}/password")
+	public ResponseEntity<Boolean> changePassword(
+			@PathVariable int userId,
+			@RequestBody ChangePasswordRequestDto requestDto,
+			Authentication authentication) {
+
+		if(authentication == null || !authentication.isAuthenticated() ||
+		authentication.getPrincipal() instanceof String) {
+			return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(false);
+		}
+
+		LoginResponseDto loginUser = (LoginResponseDto) authentication.getPrincipal();
+
+		if(loginUser.getId() != userId) {
+			return ResponseEntity.status(HttpStatus.FORBIDDEN).body(false);
+		}
+
+		userService.changePassword(userId, requestDto);
+		return ResponseEntity.ok(true);
 	}
 }

--- a/src/main/java/com/mycom/myapp/user/controller/UserController.java
+++ b/src/main/java/com/mycom/myapp/user/controller/UserController.java
@@ -34,9 +34,8 @@ public class UserController {
 	    return ResponseEntity.ok(!isDuplicate);
 	}
 
-	@PutMapping("{userId}/password")
+	@PutMapping("/password")
 	public ResponseEntity<Boolean> changePassword(
-			@PathVariable int userId,
 			@RequestBody ChangePasswordRequestDto requestDto,
 			Authentication authentication) {
 
@@ -47,11 +46,7 @@ public class UserController {
 
 		LoginResponseDto loginUser = (LoginResponseDto) authentication.getPrincipal();
 
-		if(loginUser.getId() != userId) {
-			return ResponseEntity.status(HttpStatus.FORBIDDEN).body(false);
-		}
-
-		userService.changePassword(userId, requestDto);
+		userService.changePassword(loginUser.getId(), requestDto);
 		return ResponseEntity.ok(true);
 	}
 }

--- a/src/main/java/com/mycom/myapp/user/dto/ChangePasswordRequestDto.java
+++ b/src/main/java/com/mycom/myapp/user/dto/ChangePasswordRequestDto.java
@@ -1,0 +1,9 @@
+package com.mycom.myapp.user.dto;
+
+import lombok.Data;
+
+@Data
+public class ChangePasswordRequestDto {
+    private String currentPassword;
+    private String newPassword;
+}

--- a/src/main/java/com/mycom/myapp/user/service/UserService.java
+++ b/src/main/java/com/mycom/myapp/user/service/UserService.java
@@ -1,8 +1,11 @@
 package com.mycom.myapp.user.service;
 
+import com.mycom.myapp.user.dto.ChangePasswordRequestDto;
 import com.mycom.myapp.user.dto.UserRegisterRequestDto;
 
 public interface UserService {
 	boolean insertUser(UserRegisterRequestDto userRegisterRequestDto);
 	boolean isEmailDuplicate(String email);
+
+	void changePassword(int userId, ChangePasswordRequestDto requestDto);
 }

--- a/src/main/java/com/mycom/myapp/user/service/UserServiceImpl.java
+++ b/src/main/java/com/mycom/myapp/user/service/UserServiceImpl.java
@@ -1,5 +1,6 @@
 package com.mycom.myapp.user.service;
 
+import com.mycom.myapp.user.dto.ChangePasswordRequestDto;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -40,6 +41,19 @@ public class UserServiceImpl implements UserService{
 	@Override
 	public boolean isEmailDuplicate(String email) {
 		return userRepository.findByEmail(email).isPresent();
+	}
+
+	@Override
+	public void changePassword(int userId, ChangePasswordRequestDto requestDto) {
+		User user = userRepository.findById(userId)
+				.orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+		if(!passwordEncoder.matches(requestDto.getCurrentPassword(), user.getPassword())) {
+			throw new IllegalArgumentException("현재 비밀번호가 일치하지 않습니다.");
+		}
+
+		user.setPassword(passwordEncoder.encode(requestDto.getNewPassword()));
+		userRepository.save(user);
 	}
 }
 


### PR DESCRIPTION
**주요 변경 사항**
- 비밀번호 변경 기능 구현 (`PUT /api/user/password`)
-> /api/user/{userId} 이렇게 할 경우에는  어떤 필드를 바꾸는 건지 URL만 보고 모르기 때문에 /api/user/password 이렇게 변경하여 로그인한 userId를 그대로 받고, 비밀번호를 변경한다는 것을 알 수 있게 해주었습니다.

- 로그인 성공 시 SecurityContext 및 세션에 인증 정보 저장 처리
- Spring Security 설정 수정: 비밀번호 변경 API는 인증 없이 접근 가능하도록 예외 처리

**문제 상황**
1. 비밀번호 변경 요청 시 403 에러 발생
2. Spring Security가 인증되지 않은 상태로 판단

**해결 방법**
1. **SecurityConfig 수정**:
    - 비밀번호 변경 URL에 대해 일시적으로 인증 요구사항 완화 (`permitAll`)
    - SecurityContext 저장소 명시적 설정
    - 세션 생성 정책 명확히 지정
2. **로그인 과정 개선**:
    - 인증 객체 생성 시 세부 정보 추가
    - 빈 SecurityContext 생성 후 설정
    - SecurityContext를 세션에 명시적으로 저장
3. **컨트롤러 변경**:
    - HttpSession 직접 사용에서 Authentication 객체 활용으로 변경
    - Spring Security의 인증 메커니즘과 통합

-> 비밀번호 변경할 때 인증 관련 문제가 발생하여 일단 처리하기는 하였으나 코드에 대해서는 더 공부해봐야할 것 같습니다

