### PR TITLE
프로필 수정 기능(이름, 프로필 이미지)

### DIFF
--- a/src/main/java/com/mycom/myapp/config/SecurityConfig.java
+++ b/src/main/java/com/mycom/myapp/config/SecurityConfig.java
@@ -23,7 +23,6 @@ public class SecurityConfig {
 								"/api/user/register",
 								"/api/user/email-check",
 								"/api/auth/login",
-								"/api/user/profile",
 								"/api/auth/logout"
 						).permitAll()
 						.requestMatchers("/api/user/*/password").permitAll()

--- a/src/main/java/com/mycom/myapp/config/WebMvcConfig.java
+++ b/src/main/java/com/mycom/myapp/config/WebMvcConfig.java
@@ -1,0 +1,14 @@
+package com.mycom.myapp.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("/uploads/**")
+                .addResourceLocations("file:///C:/uploads/");
+    }
+}

--- a/src/main/java/com/mycom/myapp/user/controller/UserController.java
+++ b/src/main/java/com/mycom/myapp/user/controller/UserController.java
@@ -7,12 +7,14 @@ import com.mycom.myapp.user.dto.UserProfileResponseDto;
 import com.mycom.myapp.user.dto.UserRegisterRequestDto;
 import jakarta.servlet.http.HttpSession;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import com.mycom.myapp.user.service.UserService;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/api/user")
@@ -64,6 +66,29 @@ public class UserController {
 		try {
 			UserProfileResponseDto profile = userService.getUserProfileById(loginUser.getId());
 			return ResponseEntity.ok(profile);
+		} catch (IllegalArgumentException e) {
+			return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+		}
+	}
+
+	@PutMapping(value = "/profile", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+	public ResponseEntity<UserProfileResponseDto> updateUserProfile(
+			Authentication authentication,
+			@RequestPart(value = "name", required = false) String name,
+			@RequestPart(value = "profileImage", required = false) MultipartFile profileImage) {
+
+		if(authentication == null || !authentication.isAuthenticated() ||
+				authentication.getPrincipal() instanceof String) {
+			return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+		}
+
+		LoginResponseDto loginUser = (LoginResponseDto) authentication.getPrincipal();
+
+		try {
+			UserProfileResponseDto updatedProfile = userService.updateUserProfile(
+					loginUser.getId(), name, profileImage
+			);
+			return ResponseEntity.ok(updatedProfile);
 		} catch (IllegalArgumentException e) {
 			return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
 		}

--- a/src/main/java/com/mycom/myapp/user/controller/UserController.java
+++ b/src/main/java/com/mycom/myapp/user/controller/UserController.java
@@ -55,43 +55,31 @@ public class UserController {
 	}
 
 	@GetMapping("/profile")
-	public ResponseEntity<UserProfileResponseDto> getUserProfile(Authentication authentication) {
-		if(authentication == null || !authentication.isAuthenticated() ||
-				authentication.getPrincipal() instanceof String) {
-			return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
-		}
-
-		LoginResponseDto loginUser = (LoginResponseDto) authentication.getPrincipal();
-
+	public ResponseEntity<UserProfileResponseDto> getUserProfile() {
 		try {
-			UserProfileResponseDto profile = userService.getUserProfileById(loginUser.getId());
+			UserProfileResponseDto profile = userService.getUserProfile();
 			return ResponseEntity.ok(profile);
 		} catch (IllegalArgumentException e) {
 			return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+		} catch (IllegalStateException e) {
+			return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
 		}
 	}
 
 	@PutMapping(value = "/profile", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
 	public ResponseEntity<UserProfileResponseDto> updateUserProfile(
-			Authentication authentication,
 			@RequestPart(value = "name", required = false) String name,
 			@RequestPart(value = "profileImage", required = false) MultipartFile profileImage) {
 
-		if(authentication == null || !authentication.isAuthenticated() ||
-				authentication.getPrincipal() instanceof String) {
-			return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
-		}
-
-		LoginResponseDto loginUser = (LoginResponseDto) authentication.getPrincipal();
-
 		try {
-			UserProfileResponseDto updatedProfile = userService.updateUserProfile(
-					loginUser.getId(), name, profileImage
-			);
+			UserProfileResponseDto updatedProfile = userService.updateUserProfile(name, profileImage);
 			return ResponseEntity.ok(updatedProfile);
 		} catch (IllegalArgumentException e) {
 			return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+		} catch (IllegalStateException e) {
+			return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
 		}
 	}
+
 }
 

--- a/src/main/java/com/mycom/myapp/user/service/UserService.java
+++ b/src/main/java/com/mycom/myapp/user/service/UserService.java
@@ -3,6 +3,7 @@ package com.mycom.myapp.user.service;
 import com.mycom.myapp.user.dto.ChangePasswordRequestDto;
 import com.mycom.myapp.user.dto.UserProfileResponseDto;
 import com.mycom.myapp.user.dto.UserRegisterRequestDto;
+import org.springframework.web.multipart.MultipartFile;
 
 public interface UserService {
 	boolean insertUser(UserRegisterRequestDto userRegisterRequestDto);
@@ -10,4 +11,6 @@ public interface UserService {
 	UserProfileResponseDto getUserProfileById(int userId);
 
 	void changePassword(int userId, ChangePasswordRequestDto requestDto);
+
+	UserProfileResponseDto updateUserProfile(int userId, String name, MultipartFile imageFile);
 }

--- a/src/main/java/com/mycom/myapp/user/service/UserService.java
+++ b/src/main/java/com/mycom/myapp/user/service/UserService.java
@@ -7,10 +7,12 @@ import org.springframework.web.multipart.MultipartFile;
 
 public interface UserService {
 	boolean insertUser(UserRegisterRequestDto userRegisterRequestDto);
+
 	boolean isEmailDuplicate(String email);
-	UserProfileResponseDto getUserProfileById(int userId);
+
+	UserProfileResponseDto getUserProfile();
 
 	void changePassword(int userId, ChangePasswordRequestDto requestDto);
 
-	UserProfileResponseDto updateUserProfile(int userId, String name, MultipartFile imageFile);
+	UserProfileResponseDto updateUserProfile(String name, MultipartFile profileImage);
 }


### PR DESCRIPTION
**변경내용**

- SecurityConfig: /api/user/profile 경로 permitAll에서 제거

- insertUser(): 회원가입 시 기본 프로필 파일명에서 파일 경로로 변경
"/uploads/profile/profile_noProfile.png"

- service쪽에서 로그인 사용자 정보 조회하도록 변경

**구현내용** 
프로필 수정 기능

- config 패키지에 WebMvcConfig 추가

- UserController에 /api/user/profile 구현 (명세에 반영)

- UserServiceImpl에 updateUserProfile 메소드 구현 
-C:/uploads/profile/ -> 이미지 저장 경로(로컬)
-/uploads/profile/profile_{userId}_{timestamp}_{원래파일명} -> 이렇게 db에 저장(profile_img 컬럼에)

--> 지금은 제 로컬에 이미지 파일이 있고 db에는 이미지 경로가 저장되어 있습니다.

