### PR TITLE
리뷰 수정 기능 개발

### DIFF
--- a/src/main/java/com/mycom/myapp/review/controller/ReviewController.java
+++ b/src/main/java/com/mycom/myapp/review/controller/ReviewController.java
@@ -1,0 +1,43 @@
+package com.mycom.myapp.review.controller;
+
+import com.mycom.myapp.auth.dto.response.LoginResponseDto;
+import com.mycom.myapp.review.dto.ReviewUpdateRequestDto;
+import com.mycom.myapp.review.dto.ReviewUpdateResponseDto;
+import com.mycom.myapp.review.service.ReviewService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/review")
+@RequiredArgsConstructor
+public class ReviewController {
+
+    private final ReviewService reviewService;
+
+    @PutMapping("/{reviewId}")
+    public ResponseEntity<ReviewUpdateResponseDto> updateReview(
+            @PathVariable("reviewId") int reviewId,
+            @RequestBody ReviewUpdateRequestDto dto,
+            Authentication authentication) {
+
+        if(authentication == null || !authentication.isAuthenticated() ||
+                authentication.getPrincipal() instanceof String) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(null);
+        }
+
+        LoginResponseDto loginUser = (LoginResponseDto) authentication.getPrincipal();
+
+        try {
+            ReviewUpdateResponseDto updatedReview = reviewService.updateReview(reviewId, loginUser, dto);
+            return ResponseEntity.ok(updatedReview);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+        } catch (SecurityException e) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
+    }
+
+}

--- a/src/main/java/com/mycom/myapp/review/controller/ReviewController.java
+++ b/src/main/java/com/mycom/myapp/review/controller/ReviewController.java
@@ -35,9 +35,9 @@ public class ReviewController {
         return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
     }
 
-    @PutMapping("/{reviewId}")
+    @PutMapping("/{review_id}")
     public ResponseEntity<ReviewUpdateResponseDto> updateReview(
-            @PathVariable("reviewId") int reviewId,
+            @PathVariable("review_id") int reviewId,
             @RequestBody ReviewUpdateRequestDto dto,
             Authentication authentication) {
 

--- a/src/main/java/com/mycom/myapp/review/dto/ReviewUpdateRequestDto.java
+++ b/src/main/java/com/mycom/myapp/review/dto/ReviewUpdateRequestDto.java
@@ -1,0 +1,9 @@
+package com.mycom.myapp.review.dto;
+
+import lombok.Data;
+
+@Data
+public class ReviewUpdateRequestDto {
+    private String title;
+    private String content;
+}

--- a/src/main/java/com/mycom/myapp/review/dto/ReviewUpdateResponseDto.java
+++ b/src/main/java/com/mycom/myapp/review/dto/ReviewUpdateResponseDto.java
@@ -1,0 +1,18 @@
+package com.mycom.myapp.review.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+public class ReviewUpdateResponseDto {
+    private int id;
+    private String userName;
+    private String region;
+    private String title;
+    private String content;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/mycom/myapp/review/entity/Review.java
+++ b/src/main/java/com/mycom/myapp/review/entity/Review.java
@@ -30,7 +30,7 @@ public class Review {
     @Column(name="created_at")
     private LocalDateTime createdAt;
 
-    @Column(name = "updated_at")
+    @Column(name="updated_at")
     private LocalDateTime updatedAt;
 
     @PrePersist

--- a/src/main/java/com/mycom/myapp/review/entity/Review.java
+++ b/src/main/java/com/mycom/myapp/review/entity/Review.java
@@ -1,0 +1,46 @@
+package com.mycom.myapp.review.entity;
+
+import com.mycom.myapp.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name="reviews")
+@Setter
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Review {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    private String region;
+    private String title;
+    private String content;
+
+    @Column(name="created_at")
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+}

--- a/src/main/java/com/mycom/myapp/review/repository/ReviewRepository.java
+++ b/src/main/java/com/mycom/myapp/review/repository/ReviewRepository.java
@@ -1,0 +1,7 @@
+package com.mycom.myapp.review.repository;
+
+import com.mycom.myapp.review.entity.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewRepository extends JpaRepository<Review, Integer> {
+}

--- a/src/main/java/com/mycom/myapp/review/service/ReviewService.java
+++ b/src/main/java/com/mycom/myapp/review/service/ReviewService.java
@@ -1,0 +1,9 @@
+package com.mycom.myapp.review.service;
+
+import com.mycom.myapp.auth.dto.response.LoginResponseDto;
+import com.mycom.myapp.review.dto.ReviewUpdateRequestDto;
+import com.mycom.myapp.review.dto.ReviewUpdateResponseDto;
+
+public interface ReviewService {
+    ReviewUpdateResponseDto updateReview(int reviewId, LoginResponseDto loginUser, ReviewUpdateRequestDto dto);
+}

--- a/src/main/java/com/mycom/myapp/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/mycom/myapp/review/service/ReviewServiceImpl.java
@@ -1,0 +1,55 @@
+package com.mycom.myapp.review.service;
+
+import com.mycom.myapp.auth.dto.response.LoginResponseDto;
+import com.mycom.myapp.review.dto.ReviewUpdateRequestDto;
+import com.mycom.myapp.review.dto.ReviewUpdateResponseDto;
+import com.mycom.myapp.review.entity.Review;
+import com.mycom.myapp.review.repository.ReviewRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewServiceImpl implements ReviewService{
+
+    private final ReviewRepository reviewRepository;
+    @Override
+    @Transactional
+    public ReviewUpdateResponseDto updateReview(int reviewId, LoginResponseDto loginUser, ReviewUpdateRequestDto dto){
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new IllegalArgumentException("리뷰를 찾을 수 없습니다."));
+
+        if (review.getUser().getId() != loginUser.getId()) {
+            throw new SecurityException("본인만 리뷰를 수정할 수 있습니다.");
+        }
+
+        if (!StringUtils.hasText(dto.getTitle()) && !StringUtils.hasText(dto.getContent())) {
+            throw new IllegalArgumentException("수정할 제목 또는 내용을 입력하세요.");
+        }
+
+        if (StringUtils.hasText(dto.getTitle())) {
+            review.setTitle(dto.getTitle().trim());
+        }
+
+        if (StringUtils.hasText(dto.getContent())) {
+            review.setContent(dto.getContent().trim());
+        }
+
+        reviewRepository.flush();
+
+        return ReviewUpdateResponseDto.builder()
+                .id(review.getId())
+                .userName(review.getUser().getName())
+                .region(review.getRegion())
+                .title(review.getTitle())
+                .content(review.getContent())
+                .createdAt(review.getCreatedAt())
+                .updatedAt(review.getUpdatedAt())
+                .build();
+    }
+
+}

--- a/src/main/java/com/mycom/myapp/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/mycom/myapp/review/service/ReviewServiceImpl.java
@@ -35,7 +35,6 @@ public class ReviewServiceImpl implements ReviewService {
                 .region(requestDto.getRegion())
                 .title(requestDto.getTitle())
                 .content(requestDto.getContent())
-                .createdAt(LocalDateTime.now())
                 .build();
 
         Review saved = reviewRepository.save(review);
@@ -60,15 +59,32 @@ public class ReviewServiceImpl implements ReviewService {
             throw new SecurityException("본인만 리뷰를 수정할 수 있습니다.");
         }
 
-        if (!StringUtils.hasText(dto.getTitle()) && !StringUtils.hasText(dto.getContent())) {
-            throw new IllegalArgumentException("수정할 제목 또는 내용을 입력하세요.");
+        boolean isTitleModified = dto.getTitle() != null;
+        boolean isContentModified = dto.getContent() != null;
+
+        if (!isTitleModified && !isContentModified) {
+            return ReviewUpdateResponseDto.builder()
+                    .id(review.getId())
+                    .userName(review.getUser().getName())
+                    .region(review.getRegion())
+                    .title(review.getTitle())
+                    .content(review.getContent())
+                    .createdAt(review.getCreatedAt())
+                    .updatedAt(review.getUpdatedAt())
+                    .build();
         }
 
-        if (StringUtils.hasText(dto.getTitle())) {
+        if (isTitleModified) {
+            if (dto.getTitle().trim().isEmpty()) {
+                throw new IllegalArgumentException("제목을 빈 칸으로 수정할 수 없습니다.");
+            }
             review.setTitle(dto.getTitle().trim());
         }
 
-        if (StringUtils.hasText(dto.getContent())) {
+        if (isContentModified) {
+            if (dto.getContent().trim().isEmpty()) {
+                throw new IllegalArgumentException("내용을 빈 칸으로 수정할 수 없습니다.");
+            }
             review.setContent(dto.getContent().trim());
         }
 


### PR DESCRIPTION
### **주요 내용**

- ReviewController: ReviewUpdateRequestDto를 통해 제목이나 내용 수정

- ReviewServiceImpl
-원래 있던 제목이나 내용을 아예 지우고 비워 둘 수 없도록 예외처리
-수정 시간은 서버 시간에 맞게 업데이트

- Review(Entity)
-처음 저장될 때 생성일, 수정일 자동 등록
-수정될 때 자동으로 수정일만 변경

### **예외처리에 대한 부분**
지금 컨트롤러에서 저는 다 하고있는데 괜찮을까요? 

### **테이블**
CREATE TABLE reviews (
    id INT AUTO_INCREMENT PRIMARY KEY,                      -- 리뷰 ID (PK)
    user_id INT NOT NULL,                                    -- 작성자 (users 테이블의 id 참조)
    region VARCHAR(100) NOT NULL,                            -- 지역
    title VARCHAR(255) NOT NULL,                             -- 제목
    content TEXT NOT NULL,                                   -- 내용
    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,  -- 작성일시 (등록 시 자동)
    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,  -- 수정일시 (수정 시 자동 갱신)
    CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES users(id) -- 외래키 제약조건
);

### **최신 변경 내용**

- ReviewServiceImpl: writeReview()에서 createdAt 따로 값을 넣지 않아도 되도록 수정

- 리뷰 수정 필드 유효성 검사 변경
-제목, 내용은 비워둘 수 없음
-둘 다 수정, 둘 중 하나만 수정 가능
-수정하지 않아도 정상  입력
--> 이 부분이 어려웠는데 일단 이렇게 되는 것 같습니다. 코드 확인 부탁드립니다.