### PR TITLE
비밀번호 변경 API 인증 필수화 (permitAll 제거)

### DIFF
--- a/src/main/java/com/mycom/myapp/config/SecurityConfig.java
+++ b/src/main/java/com/mycom/myapp/config/SecurityConfig.java
@@ -25,7 +25,6 @@ public class SecurityConfig {
 								"/api/auth/login",
 								"/api/auth/logout"
 						).permitAll()
-						.requestMatchers("/api/user/*/password").permitAll()
 						.anyRequest().authenticated()
 				)
 				.sessionManagement(session -> session


### PR DESCRIPTION
이 부분 비밀번호 변경 부분인데 지금 발견해서 수정해놨습니다.

**변경 내용**
Spring Security 설정에서 `PUT /api/user/password`에 대해 `permitAll()` 설정을 제거했습니다.
로그인하지 않은 사용자는 비밀번호 변경 API에 접근할 수 없게 수정하였습니다.