### PR TITLE
리뷰 작성 및 조회 로직에서 지역명(region name) → 지역 ID(region_id)로 변경

### DIFF
--- a/src/main/java/com/mycom/myapp/config/SecurityConfig.java
+++ b/src/main/java/com/mycom/myapp/config/SecurityConfig.java
@@ -23,7 +23,8 @@ public class SecurityConfig {
 								"/api/user/register",
 								"/api/user/email-check",
 								"/api/auth/login",
-								"/api/auth/logout"
+								"/api/auth/logout",
+								"/api/review"
 						).permitAll()
 						.anyRequest().authenticated()
 				)

--- a/src/main/java/com/mycom/myapp/review/dto/ReviewRequestDto.java
+++ b/src/main/java/com/mycom/myapp/review/dto/ReviewRequestDto.java
@@ -4,7 +4,7 @@ import lombok.Data;
 
 @Data
 public class ReviewRequestDto {
-    private String region;
+    private int regionId;
     private String title;
     private String content;
 }

--- a/src/main/java/com/mycom/myapp/review/entity/Region.java
+++ b/src/main/java/com/mycom/myapp/review/entity/Region.java
@@ -1,0 +1,18 @@
+package com.mycom.myapp.review.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name="region")
+@Setter
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Region {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+    private String name;
+}

--- a/src/main/java/com/mycom/myapp/review/entity/Review.java
+++ b/src/main/java/com/mycom/myapp/review/entity/Review.java
@@ -23,7 +23,10 @@ public class Review {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    private String region;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "region_id", nullable = false)
+    private Region region;
+
     private String title;
     private String content;
 

--- a/src/main/java/com/mycom/myapp/review/repository/RegionRepository.java
+++ b/src/main/java/com/mycom/myapp/review/repository/RegionRepository.java
@@ -1,0 +1,7 @@
+package com.mycom.myapp.review.repository;
+
+import com.mycom.myapp.review.entity.Region;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RegionRepository extends JpaRepository<Region, Integer> {
+}

--- a/src/main/java/com/mycom/myapp/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/mycom/myapp/review/service/ReviewServiceImpl.java
@@ -3,8 +3,10 @@ package com.mycom.myapp.review.service;
 import com.mycom.myapp.auth.dto.response.LoginResponseDto;
 import com.mycom.myapp.review.dto.*;
 import com.mycom.myapp.review.entity.Like;
+import com.mycom.myapp.review.entity.Region;
 import com.mycom.myapp.review.entity.Review;
 import com.mycom.myapp.review.repository.LikeRepository;
+import com.mycom.myapp.review.repository.RegionRepository;
 import com.mycom.myapp.review.repository.ReviewRepository;
 import com.mycom.myapp.user.entity.User;
 import com.mycom.myapp.user.repository.UserRepository;
@@ -24,19 +26,24 @@ public class ReviewServiceImpl implements ReviewService {
     private final ReviewRepository reviewRepository;
     private final UserRepository userRepository;
     private final LikeRepository likeRepository;
+    private final RegionRepository regionRepository;
 
     @Override
     public ReviewResponseDto writeReview(ReviewRequestDto requestDto, LoginResponseDto loginUser) {
         User user = userRepository.findById(loginUser.getId())
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
 
+        Region region = regionRepository.findById(requestDto.getRegionId())
+                .orElseThrow( () -> new IllegalArgumentException("해당 지역을 찾을 수 없습니다."));
+
         Review review = Review.builder()
                 .user(user)
-                .region(requestDto.getRegion())
+                .region(region)
                 .title(requestDto.getTitle())
                 .content(requestDto.getContent())
                 .createdAt(LocalDateTime.now())
                 .updatedAt(LocalDateTime.now())
+                .likesCount(0)
                 .build();
 
         Review saved = reviewRepository.save(review);
@@ -44,7 +51,7 @@ public class ReviewServiceImpl implements ReviewService {
         return ReviewResponseDto.builder()
                 .id(saved.getId())
                 .userName(user.getName())
-                .region(saved.getRegion())
+                .region(saved.getRegion().getName())
                 .title(saved.getTitle())
                 .content(saved.getContent())
                 .createdAt(saved.getCreatedAt())
@@ -150,7 +157,7 @@ public class ReviewServiceImpl implements ReviewService {
                 .map(review -> ReviewResponseDto.builder()
                         .id(review.getId())
                         .userName(review.getUser().getName())
-                        .region(review.getRegion())
+                        .region(review.getRegion().getName())
                         .title(review.getTitle())
                         .content(review.getContent())
                         .createdAt(review.getCreatedAt())


### PR DESCRIPTION
**변경 내용**

- 기존 리뷰 작성 시 지역명을 문자열로 받던 부분을 region_id를 사용하도록 변경

- 전체 리뷰 조회 시에도 region 필드가 지역명이 아닌 Region 객체의 정보를 포함하도록 수정

- 좋아요 기능에서 리뷰 정보 조회 시도 변경된 구조에 맞게 반영