### PR TITLE
지역별 리뷰 목록 조회 기능 추가

### DIFF
--- a/src/main/java/com/mycom/myapp/config/SecurityConfig.java
+++ b/src/main/java/com/mycom/myapp/config/SecurityConfig.java
@@ -24,7 +24,8 @@ public class SecurityConfig {
 								"/api/user/email-check",
 								"/api/auth/login",
 								"/api/auth/logout",
-								"/api/review"
+								"/api/review",
+								"/api/review/*"
 						).permitAll()
 						.anyRequest().authenticated()
 				)

--- a/src/main/java/com/mycom/myapp/region/entity/Region.java
+++ b/src/main/java/com/mycom/myapp/region/entity/Region.java
@@ -1,4 +1,4 @@
-package com.mycom.myapp.review.entity;
+package com.mycom.myapp.region.entity;
 
 import jakarta.persistence.*;
 import lombok.*;

--- a/src/main/java/com/mycom/myapp/region/repository/RegionRepository.java
+++ b/src/main/java/com/mycom/myapp/region/repository/RegionRepository.java
@@ -1,6 +1,6 @@
-package com.mycom.myapp.review.repository;
+package com.mycom.myapp.region.repository;
 
-import com.mycom.myapp.review.entity.Region;
+import com.mycom.myapp.region.entity.Region;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RegionRepository extends JpaRepository<Region, Integer> {

--- a/src/main/java/com/mycom/myapp/review/controller/ReviewController.java
+++ b/src/main/java/com/mycom/myapp/review/controller/ReviewController.java
@@ -99,4 +99,10 @@ public class ReviewController {
         }
     }
 
+    @GetMapping("/{region_id}")
+    public ResponseEntity<List<ReviewResponseDto>> getReviewsByRegion(@PathVariable("region_id") int regionId) {
+        List<ReviewResponseDto> reviews = reviewService.getReviewsByRegionSortedByLikes(regionId);
+        return ResponseEntity.ok(reviews);
+    }
+
 }

--- a/src/main/java/com/mycom/myapp/review/entity/Review.java
+++ b/src/main/java/com/mycom/myapp/review/entity/Review.java
@@ -1,5 +1,6 @@
 package com.mycom.myapp.review.entity;
 
+import com.mycom.myapp.region.entity.Region;
 import com.mycom.myapp.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;

--- a/src/main/java/com/mycom/myapp/review/repository/ReviewRepository.java
+++ b/src/main/java/com/mycom/myapp/review/repository/ReviewRepository.java
@@ -3,6 +3,7 @@ package com.mycom.myapp.review.repository;
 import com.mycom.myapp.review.entity.Review;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -10,4 +11,8 @@ public interface ReviewRepository extends JpaRepository<Review, Integer> {
 
     @Query("SELECT r FROM Review r JOIN FETCH r.user JOIN FETCH r.region ORDER BY r.likesCount DESC")
     List<Review> findAllWithUserSortedByLikes();
+
+    @Query("SELECT r FROM Review r JOIN FETCH r.user JOIN FETCH r.region WHERE r.region.id = :regionId ORDER BY r.likesCount DESC")
+    List<Review> findAllByRegionIdSortedByLikes(@Param("regionId") int regionId);
+
 }

--- a/src/main/java/com/mycom/myapp/review/service/ReviewService.java
+++ b/src/main/java/com/mycom/myapp/review/service/ReviewService.java
@@ -12,4 +12,5 @@ public interface ReviewService {
     List<ReviewResponseDto> getAllReviewsSortedByLikes();
 
     void deleteReview(int reviewId, LoginResponseDto loginUser);
+    List<ReviewResponseDto> getReviewsByRegionSortedByLikes(int regionId);
 }

--- a/src/main/java/com/mycom/myapp/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/mycom/myapp/review/service/ReviewServiceImpl.java
@@ -181,4 +181,22 @@ public class ReviewServiceImpl implements ReviewService {
         reviewRepository.delete(review);
     }
 
+    @Override
+    public List<ReviewResponseDto> getReviewsByRegionSortedByLikes(int regionId) {
+        List<Review> reviews = reviewRepository.findAllByRegionIdSortedByLikes(regionId);
+
+        return reviews.stream()
+                .map(review -> ReviewResponseDto.builder()
+                        .id(review.getId())
+                        .userName(review.getUser().getName())
+                        .region(review.getRegion().getName())
+                        .title(review.getTitle())
+                        .content(review.getContent())
+                        .createdAt(review.getCreatedAt())
+                        .updatedAt(review.getUpdatedAt())
+                        .likesCount(review.getLikesCount())
+                        .build())
+                .collect(Collectors.toList());
+    }
+
 }

--- a/src/main/java/com/mycom/myapp/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/mycom/myapp/review/service/ReviewServiceImpl.java
@@ -1,12 +1,13 @@
 package com.mycom.myapp.review.service;
 
 import com.mycom.myapp.auth.dto.response.LoginResponseDto;
+import com.mycom.myapp.region.entity.Region;
+import com.mycom.myapp.region.repository.RegionRepository;
 import com.mycom.myapp.review.dto.*;
 import com.mycom.myapp.review.entity.Like;
-import com.mycom.myapp.review.entity.Region;
+
 import com.mycom.myapp.review.entity.Review;
 import com.mycom.myapp.review.repository.LikeRepository;
-import com.mycom.myapp.review.repository.RegionRepository;
 import com.mycom.myapp.review.repository.ReviewRepository;
 import com.mycom.myapp.user.entity.User;
 import com.mycom.myapp.user.repository.UserRepository;
@@ -18,6 +19,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+
 
 @Service
 @RequiredArgsConstructor


### PR DESCRIPTION
### 주요 내용

- 로그인 하지 않은 사용자도 지역별 리뷰 목록 조회 가능
-SecurityConfig: "/api/review/*" 경로 permitAll()에 추가

- ReviewController: /api/review/{region_code}
-해당 지역의 리뷰가 없을 경우 [] 반환
-해당 지역의 리뷰가 있을 경우 좋아요 수 기준으로 내림 차순 정렬